### PR TITLE
Components/BuzzController: remove unused dependencies

### DIFF
--- a/src/Components/BuzzController.tsx
+++ b/src/Components/BuzzController.tsx
@@ -1,7 +1,7 @@
 import type { Team } from "../Context/GameManagementContext";
 import { Button, Flex } from "antd";
 import '../css/buzzer-item.css';
-import { IoCheckmarkDoneSharp, IoCheckmarkSharp, IoCloseSharp, IoStar, IoStarHalf, IoStarOutline } from "react-icons/io5";
+import { IoCheckmarkDoneSharp, IoCheckmarkSharp, IoCloseSharp} from "react-icons/io5";
 import { useApiContext } from "../Hooks/useApiContext";
 import useNeonBeatGame from "../Hooks/useNeonBeatGame";
 import { useContext } from "react";


### PR DESCRIPTION
Those unused dependencies trigger build errors:

  > tsc -b && vite build

  src/Components/BuzzController.tsx:4:64 - error TS6133: 'IoStar' is declared but its value is never read.

  4 import { IoCheckmarkDoneSharp, IoCheckmarkSharp, IoCloseSharp, IoStar, IoStarHalf, IoStarOutline } from "react-icons/io5";
                                                                   ~~~~~~

  src/Components/BuzzController.tsx:4:72 - error TS6133: 'IoStarHalf' is declared but its value is never read.

  4 import { IoCheckmarkDoneSharp, IoCheckmarkSharp, IoCloseSharp, IoStar, IoStarHalf, IoStarOutline } from "react-icons/io5";
                                                                           ~~~~~~~~~~

  src/Components/BuzzController.tsx:4:84 - error TS6133: 'IoStarOutline' is declared but its value is never read.

  4 import { IoCheckmarkDoneSharp, IoCheckmarkSharp, IoCloseSharp, IoStar, IoStarHalf, IoStarOutline } from "react-icons/io5";
                                                                                       ~~~~~~~~~~~~~

  Found 3 errors.