### PR TITLE
context: drop unused variable

### DIFF
--- a/src/Context/GameManagementContext.tsx
+++ b/src/Context/GameManagementContext.tsx
@@ -155,7 +155,7 @@ export const GameManagementProvider: React.FC<GameManagementProviderProps> = ({ 
   }
   const { messageApi } = messageContext;
 
-  const { sse, getQuestion, getGames, getGame, postGame, loadGame,
+  const { sse, getGames, getGame, postGame, loadGame,
     getCurrentPhase, getQuestionsSequences, postQuestionsSequence, postAnswerFound,
     getTeams, postTeam, isServerReady, postScore,
   } = useApiContext();


### PR DESCRIPTION
Trying to build the admin front leads to the following build failure:

  > neon-beat-admin-front@0.0.0 build
  > tsc -b && vite build

  src/Context/GameManagementContext.tsx:158:16 - error TS6133: 'getQuestion' is declared but its value is never read.

  158   const { sse, getQuestion, getGames, getGame, postGame, loadGame,
                     ~~~~~~~~~~~

  Found 1 error.

Fix the build failure by stopping retrieving getQuestion from useApiContext, as it is not used in the rest of the file.